### PR TITLE
fixed returned packet size in getSubPacketSize

### DIFF
--- a/src/E220.cpp
+++ b/src/E220.cpp
@@ -401,7 +401,7 @@ bool E220::setSubPacketSize(uint8_t newSize, bool permanent) {
 int E220::getSubPacketSize() {
     switch(_subPacketSize){
         case 0b00:
-            return 240;
+            return 200;
         case 0b01:
             return 128;
         case 0b10:


### PR DESCRIPTION
function _getSubPacketSize_ returns the wrong value _240_ for case _0b00_ while it should be _200_