### PR TITLE
Transmission power description printed by printBoardParameters is valid only for te 30D model

### DIFF
--- a/src/E220.cpp
+++ b/src/E220.cpp
@@ -888,16 +888,16 @@ void E220::printBoardParameters() {
         Serial.print("Transmission Power: ");
         switch (_transmitPower) {
             case 0b00:
-                Serial.println("Power_30");
+                Serial.println("22dBm (22D) / 30dBm (30D)");
                 break;
             case 0b01:
-                Serial.println("Power_27");
+                Serial.println("17dBm (22D) / 27dBm (30D)");
                 break;
             case 0b10:
-                Serial.println("Power_24");
+                Serial.println("13dBm (22D) / 24dBm (30D)");
                 break;
             case 0b11:
-                Serial.println("Power_21");
+                Serial.println("10dBm (22D) / 21dBm (30D)");
                 break;
         }
         Serial.print("Channel: ");


### PR DESCRIPTION
While setting the transmission power is correct for both models  (30D with maximum 30dBm transmission power and  22D with maximum 22dBm transmission power), when printing info in _printBoardParameters_ only values for 30D model are displayed.

As there is not any way to check which board is in use, I propose to display both values and let the owner to pick the right one.